### PR TITLE
Add some Nix stuff for building/using/developing autost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.direnv/
+/.envrc
+
 /target/
 /autost.toml
 /site/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.direnv/
 /.envrc
 
+/result
+
 /target/
 /autost.toml
 /site/*.html

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ autost is a single program you run in your terminal (`autost`).
 
 **go to [the releases page](https://github.com/delan/autost/releases) to download or install autost!**
 
+**got nix?** you can run autost *without any extra setup* using `nix run github:delan/autost`!
+
 go to [CHANGELOG.md](CHANGELOG.md) to find out what changed in each new release.
 
 for more docs, check out [the autost book](https://delan.github.io/autost/), which you can also render locally:
@@ -171,6 +173,8 @@ if you want to tinker with autost, [install rust](https://rustup.rs), then downl
 $ git clone https://github.com/delan/autost.git
 $ cd autost
 ```
+
+if you've got nix installed, there's also a devshell you can jump into with `nix-shell` or `nix develop` that has rust included. you can also build the nix derivation for autost with `nix build`.
 
 ## roadmap
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url =
+      lock.nodes.flake-compat.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734126203,
+        "narHash": "sha256-0XovF7BYP50rTD2v4r55tR5MuBLet7q4xIz6Rgh3BBU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "71a6392e367b08525ee710a93af2e80083b5b3e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       flake-utils,
       ...
@@ -16,9 +17,20 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        appliedOverlay = self.overlays.default pkgs pkgs;
       in
       {
+        packages = rec {
+          inherit (appliedOverlay) autost;
+
+          default = autost;
+        };
+
         devShell = import ./shell.nix { inherit pkgs; };
       }
-    );
+    )
+    // {
+      overlays.default = import ./nix/overlay.nix;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "github:edolstra/flake-compat";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "cohost-compatible blog engine and feed reader";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShell = import ./shell.nix { inherit pkgs; };
+      }
+    );
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,5 @@
+final: prev:
+
+{
+  autost = final.callPackage ./package.nix { };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,38 @@
+{ lib, rustPlatform }:
+
+let
+  fs = lib.fileset;
+
+  autostSources = fs.intersection (fs.gitTracked ../.) (
+    fs.unions [
+      ../Cargo.lock
+      ../Cargo.toml
+      ../autost.toml.example
+      ../src
+      ../static
+      ../templates
+    ]
+  );
+in
+rustPlatform.buildRustPackage {
+  pname = "autost";
+  version = "1.0.0";
+
+  src = fs.toSource {
+    root = ../.;
+    fileset = autostSources;
+  };
+
+  # don't forget to update this hash when Cargo.lock changes!
+  cargoHash = "sha256-IgJ/PCKgAZiV+nkNCDSIFD34IWsu0OsiuHVbjL9lVUs=";
+
+  meta = {
+    description = "cohost-compatible blog engine and feed reader";
+    homepage = "https://github.com/delan/autost";
+    downloadPage = "https://github.com/delan/autost/releases";
+    changelog = "https://github.com/delan/autost/blob/main/CHANGELOG.md";
+    license = lib.licenses.isc;
+    mainProgram = "autost";
+    platforms = lib.platforms.all;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  name = "autost-dev-shell";
+
+  packages = with pkgs; [
+    cargo
+    rustc
+    rust-analyzer
+
+    nixd
+    nixfmt-rfc-style
+  ];
+}


### PR DESCRIPTION
bringing in a few bits and pieces to the repo to make it nicely consumable with nix tooling!

- devshell containing compilers/developer tools for working in the autost codebase (`shell.nix`)
- a derivation for building autost with nix (`nix/package.nix`)
- an overlay to add autost to a nixpkgs set (`nix/overlay.nix`)
- a flake to tie it all together (`flake.nix`)
- and an interface for non-flake users to pull everything the flake provides (`default.nix`)