### PR TITLE
Add Nix builds to CI, caching build results in Cachix

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,29 @@
+name: "Nix Build/Cache"
+
+on:
+  push:
+    # Runs on pushes targeting the default branch
+    branches: ["main"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-13
+    runs-on: '${{ matrix.os }}'
+    steps:
+    - uses: actions/checkout@v4
+    # Install Nix in the runner
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    # Setup Cachix to push build results to cache
+    - uses: cachix/cachix-action@v14
+      with:
+        name: autost
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    # Run build
+    - run: nix build -L

--- a/README.md
+++ b/README.md
@@ -11,22 +11,6 @@ autost is a single program you run in your terminal (`autost`).
 
 **go to [the releases page](https://github.com/delan/autost/releases) to download or install autost!**
 
-**got nix?** you can run autost *without any extra setup* using `nix run github:delan/autost`!
-
-if nix builds are too slow, there's a binary cache available through [cachix](https://cachix.org) - you can set it up by running `nix run nixpkgs#cachix use autost`, or for nixos:
-```nix
-{
-  nix.settings = {
-    substituters = [
-      "https://autost.cachix.org"
-    ];
-    trusted-public-keys = [
-      "autost.cachix.org-1:zl/QINkEtBrk/TVeogtROIpQwQH6QjQWTPkbPNNsgpk="
-    ];
-  }
-}
-```
-
 go to [CHANGELOG.md](CHANGELOG.md) to find out what changed in each new release.
 
 for more docs, check out [the autost book](https://delan.github.io/autost/), which you can also render locally:
@@ -37,6 +21,8 @@ $ cargo run render
   - or -
 $ cargo run server
 ```
+
+**got nix?** you can run autost *without any extra setup* using `nix run github:delan/autost`! see [§ using autost with nix](#using-autost-with-nix) for more details.
 
 ## how to quickly archive chosts by people you follow
 
@@ -218,6 +204,22 @@ $ cd autost
 ```
 
 if you've got nix installed, there's also a devshell you can jump into with `nix-shell` or `nix develop` that has rust included. you can also build the nix derivation for autost with `nix build`.
+
+## using autost with nix
+
+if nix builds are too slow, there's a binary cache available through [cachix](https://cachix.org). you can set it up by running `nix run nixpkgs#cachix use autost`, or for nixos:
+```nix
+{
+  nix.settings = {
+    substituters = [
+      "https://autost.cachix.org"
+    ];
+    trusted-public-keys = [
+      "autost.cachix.org-1:zl/QINkEtBrk/TVeogtROIpQwQH6QjQWTPkbPNNsgpk="
+    ];
+  }
+}
+```
 
 ## roadmap
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ autost is a single program you run in your terminal (`autost`).
 
 **got nix?** you can run autost *without any extra setup* using `nix run github:delan/autost`!
 
+if nix builds are too slow, there's a binary cache available through [cachix](https://cachix.org) - you can set it up by running `nix run nixpkgs#cachix use autost`, or for nixos:
+```nix
+{
+  nix.settings = {
+    substituters = [
+      "https://autost.cachix.org"
+    ];
+    trusted-public-keys = [
+      "autost.cachix.org-1:zl/QINkEtBrk/TVeogtROIpQwQH6QjQWTPkbPNNsgpk="
+    ];
+  }
+}
+```
+
 go to [CHANGELOG.md](CHANGELOG.md) to find out what changed in each new release.
 
 for more docs, check out [the autost book](https://delan.github.io/autost/), which you can also render locally:


### PR DESCRIPTION
building off of #25, this pr includes a ci pipeline that builds autost with nix, and pushes the result into a binary cache. it builds for the following systems:
- `x86_64-linux`
- `x86_64-darwin`
- `aarch64-darwin`

instructions for end-users to setup the binary cache on their own systems are also detailed in the readme, so users don't need to compile autost on their own machines.