### PR TITLE
Add support for archiving liked posts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab99eae5ee58501ab236beb6f20f6ca39be615267b014899c89b2f0bc18a459"
 dependencies = [
- "html5ever",
+ "html5ever 0.27.0",
  "maplit",
  "once_cell",
  "tendril",
@@ -175,12 +175,13 @@ dependencies = [
  "clap",
  "comrak",
  "cssparser",
- "html5ever",
+ "html5ever 0.27.0",
  "http 0.2.12",
  "jane-eyre",
  "markup5ever_rcdom",
  "rayon",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
@@ -602,6 +603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +643,12 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -775,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +809,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -889,7 +925,21 @@ checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1218,13 +1268,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
 name = "markup5ever_rcdom"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
 dependencies = [
- "html5ever",
- "markup5ever",
+ "html5ever 0.27.0",
+ "markup5ever 0.12.1",
  "tendril",
  "xml5ever",
 ]
@@ -1909,6 +1973,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.29.0",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.6.0",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +2057,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae65c4249478a2647db249fb43e23cec56a2c8974a427e7bd8cb5a1d0964921a"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2059,6 +2166,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
@@ -2536,6 +2649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,7 +3031,7 @@ checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ http = "0.2.12"
 jane-eyre = "0.3.0"
 markup5ever_rcdom = "0.3.0"
 rayon = "1.10.0"
+scraper = "0.22.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { version = "1.0.128", features = ["unbounded_depth"] }
 sha2 = "0.10.8"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
   };
 
   # don't forget to update this hash when Cargo.lock or ${version} changes!
-  cargoHash = "sha256-stgm8rzmwWByTElcIUsgSIUKOVnfAYTQ0Et7bmC9/WQ=";
+  cargoHash = "sha256-cVY5qJrmqeETGxV2Lw00nUC+gJ8ol54N609GYiSMqmw=";
 
   meta = {
     description = "cohost-compatible blog engine and feed reader";

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ pkgs.mkShell {
   packages = with pkgs; [
     cargo
     rustc
+    rustfmt
     rust-analyzer
 
     nixd

--- a/src/cohost.rs
+++ b/src/cohost.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::warn;
 
@@ -14,7 +14,7 @@ pub struct PostsResponse {
     pub items: Vec<Value>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct Post {
     pub postId: usize,
@@ -37,7 +37,7 @@ pub struct Post {
     pub astMap: AstMap,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct PostingProject {
     pub handle: String,
@@ -46,7 +46,7 @@ pub struct PostingProject {
     pub loggedOutPostVisibility: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 #[allow(non_snake_case)]
 pub enum Block {
@@ -69,13 +69,13 @@ pub enum Block {
     },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct Markdown {
     pub content: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "kind")]
 #[allow(non_snake_case)]
 pub enum Attachment {
@@ -101,7 +101,7 @@ pub enum Attachment {
     },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct Ask {
     pub content: String,
@@ -110,20 +110,20 @@ pub struct Ask {
     pub loggedIn: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct AskingProject {
     pub handle: String,
     pub displayName: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct AstMap {
     pub spans: Vec<Span>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct Span {
     pub ast: String,
@@ -181,6 +181,31 @@ pub struct FeedProject {
 pub struct FollowedProject {
     pub projectId: usize,
     pub handle: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LikedPostsState {
+    #[serde(rename = "liked-posts-feed")]
+    pub liked_posts_feed: LikedPostsFeed,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(non_snake_case)]
+pub struct LikedPostsFeed {
+    pub posts: Vec<Post>,
+    pub paginationMode: PaginationMode,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(non_snake_case)]
+pub struct PaginationMode {
+    pub currentSkip: usize,
+    pub idealPageStride: usize,
+    pub mode: String,
+    pub morePagesForward: bool,
+    pub morePagesBackward: bool,
+    pub pageUrlFactoryName: String,
+    pub refTimestamp: usize,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/command/cohost2json.rs
+++ b/src/command/cohost2json.rs
@@ -30,6 +30,7 @@ pub async fn main(args: Cohost2json) -> eyre::Result<()> {
     let requested_project = args.project_name;
     let output_path = args.path_to_chosts;
     let output_path = Path::new(&output_path);
+    let mut dump_liked = args.liked;
     create_dir_all(output_path)?;
 
     let client = if let Ok(connect_sid) = env::var("COHOST_COOKIE") {
@@ -88,6 +89,13 @@ pub async fn main(args: Cohost2json) -> eyre::Result<()> {
                 "dumping chosts for @{}, which you don’t own",
                 requested_project
             );
+            if dump_liked {
+                warn!(
+                    "you requested liked chosts, but not your own logged in project (@{}); skipping liked chosts",
+                    logged_in_project.handle
+                );
+                dump_liked = false;
+            }
         }
 
         client
@@ -117,7 +125,7 @@ pub async fn main(args: Cohost2json) -> eyre::Result<()> {
         }
     }
 
-    if args.liked {
+    if dump_liked {
         if env::var("COHOST_COOKIE").is_err() {
             warn!("requested liked posts, but COHOST_COOKIE not provided - skipping");
         } else {

--- a/src/command/cohost_archive.rs
+++ b/src/command/cohost_archive.rs
@@ -111,7 +111,7 @@ pub async fn main(args: CohostArchive) -> eyre::Result<()> {
 
     if args.liked && !project_names.contains(&logged_in_project.handle) {
         warn!(
-            "requested liked posts, but not the logged in project (@{}) - skipping liked posts",
+            "you requested liked chosts, but not your own logged in project (@{}); skipping liked chosts",
             logged_in_project.handle
         );
     }

--- a/src/command/cohost_archive.rs
+++ b/src/command/cohost_archive.rs
@@ -110,7 +110,10 @@ pub async fn main(args: CohostArchive) -> eyre::Result<()> {
         .collect::<Vec<_>>();
 
     if args.liked && !project_names.contains(&logged_in_project.handle) {
-        warn!("requested liked posts, but not the logged in project - skipping liked posts");
+        warn!(
+            "requested liked posts, but not the logged in project (@{}) - skipping liked posts",
+            logged_in_project.handle
+        );
     }
 
     for project_name in project_names {


### PR DESCRIPTION
this pr defines a new `--liked` flag on both `cohost-archive` and `cohost2json`. when provided, autost will include the liked posts for the requested page in the archive.

notes:
- archiving liked posts only works for the logged in project. `cohost-archive` will only try to fetch liked posts for that project, and `cohost2json` will skip archiving liked posts if they were requested but no `COHOST_COOKIE` is provided
- liked posts likely aren't authored by the `self_author` for the site, so they won't end up anywhere other than `skipped_other.html`  in the rendered site without extra configuration