### PR TITLE
Fix crash on Windows when attachment filenames have `:` characters

### DIFF
--- a/src/attachments.rs
+++ b/src/attachments.rs
@@ -276,6 +276,12 @@ fn cache_cohost_attachment(
         bail!("redirect target has no slashes: {url}");
     };
     let original_filename = urlencoding::decode(original_filename)?;
+
+    // On Windows, `:` characters are not allowed in filenames (because it's used as a drive
+    // separator)
+    #[cfg(windows)]
+    let original_filename = original_filename.replace(":", "-");
+
     trace!("original filename: {original_filename}");
 
     // cohost attachment redirects don’t preserve query params, so if we want to add any,


### PR DESCRIPTION
Hi there! I noticed a crash on a particular chost from `@jessfromonline`, 971, so I went digging and noticed that it's because it had an attachment with a bunch of `:` characters in the filename. I'm using Windows, so this causes `File::create(&path)` to fail, because pathnames can't have `:` characters in them on Windows due to it being interpreted as a drive separator.

This PR just replaces `:` characters with `-` characters in attachment filenames, and specifically only on Windows.