### PR TITLE
make PostsPath constants static and actually lazy

### DIFF
--- a/src/attachments.rs
+++ b/src/attachments.rs
@@ -14,7 +14,10 @@ use uuid::Uuid;
 
 use crate::{
     cohost::{attachment_id_to_url, Cacheable},
-    path::{AttachmentsPath, SitePath},
+    path::{
+        AttachmentsPath, SitePath, ATTACHMENTS_PATH_COHOST_AVATAR, ATTACHMENTS_PATH_COHOST_HEADER,
+        ATTACHMENTS_PATH_COHOST_STATIC, ATTACHMENTS_PATH_ROOT, ATTACHMENTS_PATH_THUMBS,
+    },
 };
 
 #[derive(Debug)]
@@ -55,7 +58,7 @@ pub struct RealAttachmentsContext;
 impl AttachmentsContext for RealAttachmentsContext {
     #[tracing::instrument(skip(self))]
     fn store(&self, input_path: &Path) -> eyre::Result<AttachmentsPath> {
-        let dir = AttachmentsPath::ROOT.join(&Uuid::new_v4().to_string())?;
+        let dir = ATTACHMENTS_PATH_ROOT.join(&Uuid::new_v4().to_string())?;
         create_dir_all(&dir)?;
         let filename = input_path.file_name().ok_or_eyre("no filename")?;
         let filename = filename.to_str().ok_or_eyre("unsupported filename")?;
@@ -70,7 +73,7 @@ impl AttachmentsContext for RealAttachmentsContext {
         let mut hash = Sha256::new();
         hash.update(url);
         let hash = hash.finalize().map(|o| format!("{o:02x}")).join("");
-        let path = AttachmentsPath::ROOT.join(&format!("imported-{post_basename}-{hash}"))?;
+        let path = ATTACHMENTS_PATH_ROOT.join(&format!("imported-{post_basename}-{hash}"))?;
         trace!(?path);
         create_dir_all(&path)?;
 
@@ -85,7 +88,7 @@ impl AttachmentsContext for RealAttachmentsContext {
         match cacheable {
             Cacheable::Attachment { id, url } => {
                 let redirect_url = attachment_id_to_url(id);
-                let dir = &*AttachmentsPath::ROOT;
+                let dir = &*ATTACHMENTS_PATH_ROOT;
                 let path = dir.join(id)?;
                 create_dir_all(&path)?;
 
@@ -101,7 +104,7 @@ impl AttachmentsContext for RealAttachmentsContext {
             }
 
             Cacheable::Static { filename, url } => {
-                let dir = &*AttachmentsPath::COHOST_STATIC;
+                let dir = &*ATTACHMENTS_PATH_COHOST_STATIC;
                 create_dir_all(dir)?;
                 let path = dir.join(filename)?;
                 trace!(?path);
@@ -110,7 +113,7 @@ impl AttachmentsContext for RealAttachmentsContext {
             }
 
             Cacheable::Avatar { filename, url } => {
-                let dir = &*AttachmentsPath::COHOST_AVATAR;
+                let dir = &*ATTACHMENTS_PATH_COHOST_AVATAR;
                 create_dir_all(dir)?;
                 let path = dir.join(filename)?;
                 trace!(?path);
@@ -119,7 +122,7 @@ impl AttachmentsContext for RealAttachmentsContext {
             }
 
             Cacheable::Header { filename, url } => {
-                let dir = &*AttachmentsPath::COHOST_HEADER;
+                let dir = &*ATTACHMENTS_PATH_COHOST_HEADER;
                 create_dir_all(dir)?;
                 let path = dir.join(filename)?;
                 trace!(?path);
@@ -136,7 +139,7 @@ impl AttachmentsContext for RealAttachmentsContext {
         }
 
         let redirect_url = attachment_id_to_url(id);
-        let dir = &*AttachmentsPath::THUMBS;
+        let dir = &*ATTACHMENTS_PATH_THUMBS;
         let path = dir.join(id)?;
         create_dir_all(&path)?;
 

--- a/src/command/attach.rs
+++ b/src/command/attach.rs
@@ -6,7 +6,7 @@ use tracing::info;
 use crate::{
     attachments::{AttachmentsContext, RealAttachmentsContext},
     migrations::run_migrations,
-    path::AttachmentsPath,
+    path::ATTACHMENTS_PATH_ROOT,
 };
 
 #[derive(clap::Args, Debug)]
@@ -16,7 +16,7 @@ pub struct Attach {
 
 pub async fn main(args: Attach) -> eyre::Result<()> {
     run_migrations()?;
-    create_dir_all(&*AttachmentsPath::ROOT)?;
+    create_dir_all(&*ATTACHMENTS_PATH_ROOT)?;
 
     for path in args.paths {
         let attachment_path = RealAttachmentsContext.store(&Path::new(&path))?;

--- a/src/command/cohost2autost.rs
+++ b/src/command/cohost2autost.rs
@@ -25,7 +25,7 @@ use crate::{
         serialize_html_fragment, AttrsMutExt, AttrsRefExt, QualNameExt, TendrilExt, Transform,
     },
     migrations::run_migrations,
-    path::{PostsPath, SitePath},
+    path::{PostsPath, SitePath, POSTS_PATH_ROOT},
     render_markdown, PostMeta,
 };
 
@@ -45,7 +45,7 @@ pub fn main(args: Cohost2autost) -> eyre::Result<()> {
         .map(OsString::from)
         .collect::<Vec<_>>();
     let dir_entries = read_dir(input_path)?.collect::<Vec<_>>();
-    create_dir_all(&*PostsPath::ROOT)?;
+    create_dir_all(&*POSTS_PATH_ROOT)?;
     create_dir_all(&*SitePath::ATTACHMENTS)?;
     create_dir_all(&*SitePath::THUMBS)?;
 

--- a/src/command/cohost2autost.rs
+++ b/src/command/cohost2autost.rs
@@ -25,7 +25,7 @@ use crate::{
         serialize_html_fragment, AttrsMutExt, AttrsRefExt, QualNameExt, TendrilExt, Transform,
     },
     migrations::run_migrations,
-    path::{PostsPath, SitePath, POSTS_PATH_ROOT},
+    path::{PostsPath, SitePath, POSTS_PATH_ROOT, SITE_PATH_ATTACHMENTS, SITE_PATH_THUMBS},
     render_markdown, PostMeta,
 };
 
@@ -46,8 +46,8 @@ pub fn main(args: Cohost2autost) -> eyre::Result<()> {
         .collect::<Vec<_>>();
     let dir_entries = read_dir(input_path)?.collect::<Vec<_>>();
     create_dir_all(&*POSTS_PATH_ROOT)?;
-    create_dir_all(&*SitePath::ATTACHMENTS)?;
-    create_dir_all(&*SitePath::THUMBS)?;
+    create_dir_all(&*SITE_PATH_ATTACHMENTS)?;
+    create_dir_all(&*SITE_PATH_THUMBS)?;
 
     let span = tracing::Span::current();
     let results = dir_entries

--- a/src/command/cohost2autost.rs
+++ b/src/command/cohost2autost.rs
@@ -509,7 +509,10 @@ fn process_chost_fragment(
 
 #[test]
 fn test_render_markdown_block() -> eyre::Result<()> {
-    use crate::path::AttachmentsPath;
+    use crate::path::{
+        AttachmentsPath, ATTACHMENTS_PATH_COHOST_AVATAR, ATTACHMENTS_PATH_COHOST_HEADER,
+        ATTACHMENTS_PATH_COHOST_STATIC, ATTACHMENTS_PATH_ROOT, ATTACHMENTS_PATH_THUMBS,
+    };
     struct TestAttachmentsContext {}
     impl AttachmentsContext for TestAttachmentsContext {
         fn store(&self, _input_path: &Path) -> eyre::Result<AttachmentsPath> {
@@ -527,21 +530,21 @@ fn test_render_markdown_block() -> eyre::Result<()> {
             cacheable: &Cacheable,
         ) -> eyre::Result<CachedFileResult<AttachmentsPath>> {
             Ok(CachedFileResult::CachedPath(match cacheable {
-                Cacheable::Attachment { id, .. } => AttachmentsPath::ROOT.join(&format!("{id}"))?,
+                Cacheable::Attachment { id, .. } => ATTACHMENTS_PATH_ROOT.join(&format!("{id}"))?,
                 Cacheable::Static { filename, .. } => {
-                    AttachmentsPath::COHOST_STATIC.join(&format!("{filename}"))?
+                    ATTACHMENTS_PATH_COHOST_STATIC.join(&format!("{filename}"))?
                 }
                 Cacheable::Avatar { filename, .. } => {
-                    AttachmentsPath::COHOST_AVATAR.join(&format!("{filename}"))?
+                    ATTACHMENTS_PATH_COHOST_AVATAR.join(&format!("{filename}"))?
                 }
                 Cacheable::Header { filename, .. } => {
-                    AttachmentsPath::COHOST_HEADER.join(&format!("{filename}"))?
+                    ATTACHMENTS_PATH_COHOST_HEADER.join(&format!("{filename}"))?
                 }
             }))
         }
         fn cache_cohost_thumb(&self, id: &str) -> eyre::Result<CachedFileResult<AttachmentsPath>> {
             Ok(CachedFileResult::CachedPath(
-                AttachmentsPath::THUMBS.join(&format!("{id}"))?,
+                ATTACHMENTS_PATH_THUMBS.join(&format!("{id}"))?,
             ))
         }
     }

--- a/src/command/import.rs
+++ b/src/command/import.rs
@@ -23,7 +23,7 @@ use crate::{
         text_content, AttrsRefExt, BreadthTraverse, QualName, QualNameExt, TendrilExt,
     },
     migrations::run_migrations,
-    path::PostsPath,
+    path::{PostsPath, POSTS_PATH_IMPORTED},
     Author, PostMeta, TemplatedPost,
 };
 
@@ -41,7 +41,7 @@ pub async fn main(args: Import) -> eyre::Result<()> {
     run_migrations()?;
 
     let url = args.url;
-    create_dir_all(&*PostsPath::IMPORTED)?;
+    create_dir_all(&*POSTS_PATH_IMPORTED)?;
 
     let FetchPostResult {
         base_href,

--- a/src/command/render.rs
+++ b/src/command/render.rs
@@ -13,7 +13,7 @@ use crate::{
     meta::hard_link_attachments_into_site,
     migrations::run_migrations,
     output::{AtomFeedTemplate, ThreadsContentTemplate, ThreadsPageTemplate},
-    path::{PostsPath, SitePath, POSTS_PATH_ROOT},
+    path::{PostsPath, SitePath, POSTS_PATH_ROOT, SITE_PATH_ROOT, SITE_PATH_TAGGED},
     TemplatedPost, Thread, SETTINGS,
 };
 
@@ -58,8 +58,8 @@ pub fn render<'posts>(post_paths: Vec<PostsPath>) -> eyre::Result<()> {
     run_migrations()?;
 
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
-    create_dir_all(&*SitePath::ROOT)?;
-    create_dir_all(&*SitePath::TAGGED)?;
+    create_dir_all(&*SITE_PATH_ROOT)?;
+    create_dir_all(&*SITE_PATH_TAGGED)?;
 
     fn copy_static(output_path: &SitePath, file: &StaticFile) -> eyre::Result<()> {
         let StaticFile(filename, content) = file;
@@ -97,12 +97,12 @@ pub fn render<'posts>(post_paths: Vec<PostsPath>) -> eyre::Result<()> {
         ),
     ];
     for file in static_files.iter() {
-        copy_static(&*SitePath::ROOT, file)?;
+        copy_static(&*SITE_PATH_ROOT, file)?;
     }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let deploy_path = SitePath::ROOT.join("deploy.sh")?;
+        let deploy_path = SITE_PATH_ROOT.join("deploy.sh")?;
         let mut permissions = std::fs::metadata(&deploy_path)?.permissions();
         let mode = permissions.mode();
         permissions.set_mode(mode | 0o111);
@@ -148,12 +148,12 @@ pub fn render<'posts>(post_paths: Vec<PostsPath>) -> eyre::Result<()> {
 
     // author step: generate atom feeds.
     let atom_feed_path =
-        collections.write_atom_feed("index", &SitePath::ROOT, &now, &threads_cache)?;
+        collections.write_atom_feed("index", &SITE_PATH_ROOT, &now, &threads_cache)?;
     interesting_output_paths.insert(atom_feed_path);
 
     // generate /tagged/<tag>.feed.xml and /tagged/<tag>.html.
     for (tag, threads) in threads_by_interesting_tag {
-        let atom_feed_path = SitePath::TAGGED.join(&format!("{tag}.feed.xml"))?;
+        let atom_feed_path = SITE_PATH_TAGGED.join(&format!("{tag}.feed.xml"))?;
         let thread_refs = threads
             .iter()
             .map(|thread| &threads_cache[&thread.path].thread)
@@ -169,10 +169,10 @@ pub fn render<'posts>(post_paths: Vec<PostsPath>) -> eyre::Result<()> {
         let threads_page = ThreadsPageTemplate::render(
             &threads_content,
             &format!("#{tag} — {}", SETTINGS.site_title),
-            &Some(SitePath::TAGGED.join(&format!("{tag}.feed.xml"))?),
+            &Some(SITE_PATH_TAGGED.join(&format!("{tag}.feed.xml"))?),
         )?;
         // TODO: move this logic into path module and check for slashes
-        let threads_page_path = SitePath::TAGGED.join(&format!("{tag}.html"))?;
+        let threads_page_path = SITE_PATH_TAGGED.join(&format!("{tag}.html"))?;
         writeln!(File::create(&threads_page_path)?, "{}", threads_page)?;
         interesting_output_paths.insert(threads_page_path);
     }
@@ -195,7 +195,7 @@ pub fn render<'posts>(post_paths: Vec<PostsPath>) -> eyre::Result<()> {
         );
         // TODO: write internal collections to another dir?
         let threads_page_path =
-            collections.write_threads_page(key, &SitePath::ROOT, &threads_cache)?;
+            collections.write_threads_page(key, &SITE_PATH_ROOT, &threads_cache)?;
         if collections.is_interesting(key) {
             interesting_output_paths.insert(threads_page_path);
         }
@@ -357,7 +357,7 @@ impl Collections {
             inner: [
                 (
                     "index",
-                    Collection::new(Some(SitePath::ROOT.join("index.feed.xml")?), "posts"),
+                    Collection::new(Some(SITE_PATH_ROOT.join("index.feed.xml")?), "posts"),
                 ),
                 ("all", Collection::new(None, "all posts")),
                 (

--- a/src/command/render.rs
+++ b/src/command/render.rs
@@ -13,7 +13,7 @@ use crate::{
     meta::hard_link_attachments_into_site,
     migrations::run_migrations,
     output::{AtomFeedTemplate, ThreadsContentTemplate, ThreadsPageTemplate},
-    path::{PostsPath, SitePath},
+    path::{PostsPath, SitePath, POSTS_PATH_ROOT},
     TemplatedPost, Thread, SETTINGS,
 };
 
@@ -38,8 +38,8 @@ pub fn main(args: Render) -> eyre::Result<()> {
 pub fn render_all() -> eyre::Result<()> {
     let mut post_paths = vec![];
 
-    create_dir_all(&*PostsPath::ROOT)?;
-    for entry in read_dir(&*PostsPath::ROOT)? {
+    create_dir_all(&*POSTS_PATH_ROOT)?;
+    for entry in read_dir(&*POSTS_PATH_ROOT)? {
         let entry = entry?;
         let metadata = entry.metadata()?;
         // cohost2autost creates directories for chost thread ancestors.
@@ -47,7 +47,7 @@ pub fn render_all() -> eyre::Result<()> {
             continue;
         }
 
-        let path = PostsPath::ROOT.join_dir_entry(&entry)?;
+        let path = POSTS_PATH_ROOT.join_dir_entry(&entry)?;
         post_paths.push(path);
     }
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -24,7 +24,11 @@ use warp::{
     Filter,
 };
 
-use crate::{output::ThreadsContentTemplate, path::AttachmentsPath, SETTINGS};
+use crate::{
+    output::ThreadsContentTemplate,
+    path::{AttachmentsPath, POSTS_PATH_ROOT},
+    SETTINGS,
+};
 use crate::{
     path::{PostsPath, SitePath},
     render_markdown, PostMeta, TemplatedPost, Thread,
@@ -69,7 +73,7 @@ pub async fn main(args: Server) -> eyre::Result<()> {
                         "multiple reply_to query parameters not allowed"
                     ))));
                 };
-                let reply_to = PostsPath::ROOT.join(&reply_to).map_err(BadRequest)?;
+                let reply_to = POSTS_PATH_ROOT.join(&reply_to).map_err(BadRequest)?;
                 let post = TemplatedPost::load(&reply_to).map_err(InternalError)?;
                 let thread = Thread::try_from(post).map_err(InternalError)?;
                 thread

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -26,7 +26,7 @@ use warp::{
 
 use crate::{
     output::ThreadsContentTemplate,
-    path::{AttachmentsPath, POSTS_PATH_ROOT, SITE_PATH_ROOT},
+    path::{ATTACHMENTS_PATH_ROOT, POSTS_PATH_ROOT, SITE_PATH_ROOT},
     SETTINGS,
 };
 use crate::{path::PostsPath, render_markdown, PostMeta, TemplatedPost, Thread};
@@ -198,7 +198,7 @@ pub async fn main(args: Server) -> eyre::Result<()> {
             // render won’t have hard-linked it into the site output dir.
             let mut path: PathBuf = if segments.peek() == Some(&"attachments") {
                 segments.next();
-                (&*AttachmentsPath::ROOT).as_ref().to_owned()
+                (&*ATTACHMENTS_PATH_ROOT).as_ref().to_owned()
             } else {
                 (&*SITE_PATH_ROOT).as_ref().to_owned()
             };

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -26,13 +26,10 @@ use warp::{
 
 use crate::{
     output::ThreadsContentTemplate,
-    path::{AttachmentsPath, POSTS_PATH_ROOT},
+    path::{AttachmentsPath, POSTS_PATH_ROOT, SITE_PATH_ROOT},
     SETTINGS,
 };
-use crate::{
-    path::{PostsPath, SitePath},
-    render_markdown, PostMeta, TemplatedPost, Thread,
-};
+use crate::{path::PostsPath, render_markdown, PostMeta, TemplatedPost, Thread};
 
 use crate::command::render::render_all;
 
@@ -203,7 +200,7 @@ pub async fn main(args: Server) -> eyre::Result<()> {
                 segments.next();
                 (&*AttachmentsPath::ROOT).as_ref().to_owned()
             } else {
-                (&*SitePath::ROOT).as_ref().to_owned()
+                (&*SITE_PATH_ROOT).as_ref().to_owned()
             };
             for component in segments {
                 let component = urlencoding::decode(component)
@@ -305,7 +302,7 @@ pub async fn main(args: Server) -> eyre::Result<()> {
     let root_route = warp::path!()
         .and(warp::filters::method::get())
         .and_then(|| async {
-            let url = Uri::from_str(&SitePath::ROOT.internal_url())
+            let url = Uri::from_str(&SITE_PATH_ROOT.internal_url())
                 .wrap_err("failed to build Uri")
                 .map_err(InternalError)?;
             Ok::<_, Rejection>(temporary(url))

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -3,13 +3,13 @@ use std::fs::{create_dir_all, read_dir};
 use jane_eyre::eyre::{self, bail};
 use tracing::{info, trace};
 
-use crate::path::{hard_link_if_not_exists, SitePath};
+use crate::path::{hard_link_if_not_exists, SitePath, SITE_PATH_ATTACHMENTS};
 
 #[tracing::instrument]
 pub fn run_migrations() -> eyre::Result<()> {
     info!("hard linking attachments out of site/attachments");
-    create_dir_all(&*SitePath::ATTACHMENTS)?;
-    let mut dirs = vec![SitePath::ATTACHMENTS.to_owned()];
+    create_dir_all(&*SITE_PATH_ATTACHMENTS)?;
+    let mut dirs = vec![SITE_PATH_ATTACHMENTS.to_owned()];
     let mut files: Vec<SitePath> = vec![];
     while !dirs.is_empty() || !files.is_empty() {
         for site_path in files.drain(..) {

--- a/src/path.rs
+++ b/src/path.rs
@@ -316,30 +316,36 @@ impl SitePath {
     }
 }
 
+pub const ATTACHMENTS_PATH_ROOT: LazyLock<AttachmentsPath> = LazyLock::new(|| {
+    AttachmentsPath::new(AttachmentsKind::ROOT.into()).expect("guaranteed by argument")
+});
+pub const ATTACHMENTS_PATH_THUMBS: LazyLock<AttachmentsPath> = LazyLock::new(|| {
+    ATTACHMENTS_PATH_ROOT
+        .join("thumbs")
+        .expect("guaranteed by argument")
+});
+#[deprecated(since = "1.2.0", note = "cohost emoji are now stored in COHOST_STATIC")]
+pub const ATTACHMENTS_PATH_EMOJI: LazyLock<AttachmentsPath> = LazyLock::new(|| {
+    ATTACHMENTS_PATH_ROOT
+        .join("emoji")
+        .expect("guaranteed by argument")
+});
+pub const ATTACHMENTS_PATH_COHOST_STATIC: LazyLock<AttachmentsPath> = LazyLock::new(|| {
+    ATTACHMENTS_PATH_ROOT
+        .join("cohost-static")
+        .expect("guaranteed by argument")
+});
+pub const ATTACHMENTS_PATH_COHOST_AVATAR: LazyLock<AttachmentsPath> = LazyLock::new(|| {
+    ATTACHMENTS_PATH_ROOT
+        .join("cohost-avatar")
+        .expect("guaranteed by argument")
+});
+pub const ATTACHMENTS_PATH_COHOST_HEADER: LazyLock<AttachmentsPath> = LazyLock::new(|| {
+    ATTACHMENTS_PATH_ROOT
+        .join("cohost-header")
+        .expect("guaranteed by argument")
+});
 impl AttachmentsPath {
-    pub const ROOT: LazyLock<Self> =
-        LazyLock::new(|| Self::new(AttachmentsKind::ROOT.into()).expect("guaranteed by argument"));
-    pub const THUMBS: LazyLock<Self> =
-        LazyLock::new(|| Self::ROOT.join("thumbs").expect("guaranteed by argument"));
-    #[deprecated(since = "1.2.0", note = "cohost emoji are now stored in COHOST_STATIC")]
-    pub const EMOJI: LazyLock<Self> =
-        LazyLock::new(|| Self::ROOT.join("emoji").expect("guaranteed by argument"));
-    pub const COHOST_STATIC: LazyLock<Self> = LazyLock::new(|| {
-        Self::ROOT
-            .join("cohost-static")
-            .expect("guaranteed by argument")
-    });
-    pub const COHOST_AVATAR: LazyLock<Self> = LazyLock::new(|| {
-        Self::ROOT
-            .join("cohost-avatar")
-            .expect("guaranteed by argument")
-    });
-    pub const COHOST_HEADER: LazyLock<Self> = LazyLock::new(|| {
-        Self::ROOT
-            .join("cohost-header")
-            .expect("guaranteed by argument")
-    });
-
     pub fn site_path(&self) -> eyre::Result<SitePath> {
         let mut result = SITE_PATH_ATTACHMENTS.to_owned();
         for component in self.components() {

--- a/src/path.rs
+++ b/src/path.rs
@@ -140,12 +140,14 @@ impl<Kind: PathKind> AsRef<Path> for RelativePath<Kind> {
     }
 }
 
+pub static POSTS_PATH_ROOT: LazyLock<PostsPath> =
+    LazyLock::new(|| PostsPath::new(PostsKind::ROOT.into()).expect("guaranteed by argument"));
+pub static POSTS_PATH_IMPORTED: LazyLock<PostsPath> = LazyLock::new(|| {
+    POSTS_PATH_ROOT
+        .join("imported")
+        .expect("guaranteed by argument")
+});
 impl PostsPath {
-    pub const ROOT: LazyLock<Self> =
-        LazyLock::new(|| Self::new(PostsKind::ROOT.into()).expect("guaranteed by argument"));
-    pub const IMPORTED: LazyLock<Self> =
-        LazyLock::new(|| Self::ROOT.join("imported").expect("guaranteed by argument"));
-
     /// creates a path from `<link rel=references href>`, which is relative to
     /// the posts directory, but percent-encoded as a url.
     pub fn from_references_url(references: &str) -> eyre::Result<Self> {
@@ -156,31 +158,31 @@ impl PostsPath {
     }
 
     pub fn markdown_post_path(post_id: usize) -> Self {
-        Self::ROOT
+        POSTS_PATH_ROOT
             .join(&format!("{post_id}.md"))
             .expect("guaranteed by argument")
     }
 
     pub fn generated_post_path(post_id: usize) -> Self {
-        Self::ROOT
+        POSTS_PATH_ROOT
             .join(&format!("{post_id}.html"))
             .expect("guaranteed by argument")
     }
 
     pub fn references_dir(post_id: usize) -> Self {
-        Self::ROOT
+        POSTS_PATH_ROOT
             .join(&format!("{post_id}"))
             .expect("guaranteed by argument")
     }
 
     pub fn references_post_path(post_id: usize, references_post_id: usize) -> Self {
-        Self::ROOT
+        POSTS_PATH_ROOT
             .join(&format!("{post_id}/{references_post_id}.html"))
             .expect("guaranteed by argument")
     }
 
     pub fn imported_post_path(post_id: usize) -> Self {
-        Self::IMPORTED
+        POSTS_PATH_IMPORTED
             .join(&format!("{post_id}.html"))
             .expect("guaranteed by argument")
     }


### PR DESCRIPTION
[clippy warned us](https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const) about using `const`s because every time you reference them, they get created on the spot. we were using this for `LazyLock` to lazily evaluate the path constants, but because they were `const`, instead of `static`, rust was just evaluating the `LazyLock` every single time you used the variable. 

the easy fix would be changing them from `const` to `static`, but "associated static items are not allowed"

this pr moves constants for `PostsPath`, `SitePath`, and `AttachmentsPath` out of the `impl` and makes them `static`